### PR TITLE
Simplify wrapping HTML around code blocks

### DIFF
--- a/lib/Pod/Elemental/Transformer/SynHi.pm
+++ b/lib/Pod/Elemental/Transformer/SynHi.pm
@@ -237,10 +237,7 @@ sub standard_code_block {
   # Another stupid hack: the <code> blocks below force monospace font.  It
   # can't wrap the whole table, though, because it would cause styling issues
   # in the rendered XHTML. -- rjbs, 2009-12-10
-  $html = "<table class='code-listing'><tr>"
-        . "<td class='line-numbers'><br /><code>$nums</code><br />&nbsp;</td>"
-        . "<td class='code'><br /><code>$code</code><br />&nbsp;</td>"
-        . "</table>";
+  $html = "<pre><code class=\"code-listing\">$code</code></pre>";
 
   return $html;
 }


### PR DESCRIPTION
The current code is wrapping code inside a bit too much elements (in particular a table) which is a bit problematic because all those elements are bringing different layout and default css style.

The purpose of this change is to simplify wrapping code to the maximum (pre + code + class).

This pull request is a noop at the moment, it can be merged safely (in other words, I'm preparing you that I will maybe merge it without review/approvals 😃)

The overall idea is to use this forked version of the module in order to fix the code block overflow issue we have with Perl Advent calendar.
