### PR TITLE
Add VimHTML transformer with UTF-8 handling fix

### DIFF
--- a/lib/Pod/Elemental/Transformer/VimHTML.pm
+++ b/lib/Pod/Elemental/Transformer/VimHTML.pm
@@ -1,0 +1,59 @@
+use v5.12.0;
+package Pod::Elemental::Transformer::VimHTML;
+# ABSTRACT: transform Pod regions into syntax highlighted HTML via Text::VimColor
+
+use Moose;
+with 'Pod::Elemental::Transformer::SynHi';
+
+use Carp qw(confess);
+use Encode ();
+use Text::VimColor;
+
+has '+format_name' => (default => 'vim');
+
+sub build_html {
+  my ($self, $str, $param) = @_;
+
+  if (utf8::is_utf8($str)) {
+    if ($str =~ /[\x{00C2}\x{00C3}][\x{0080}-\x{00BF}]/) {
+      my $fixed = eval {
+        Encode::decode(
+          'utf-8',
+          Encode::encode('latin-1', $str, Encode::FB_CROAK),
+          Encode::FB_CROAK
+        );
+      };
+      $str = $fixed if defined $fixed;
+    }
+  } else {
+    $str = Encode::decode('utf-8', $str, Encode::FB_CROAK);
+  }
+
+  my $vim = Text::VimColor->new(
+    string   => $str,
+    filetype => $param->{filetype},
+    vim_options => [
+      qw( -RXZ -i NONE -u NONE -N -n ), '+set nomodeline', '+set fenc=utf-8',
+    ],
+  );
+
+  my $html = $vim->html;
+  $html = Encode::decode('utf-8', $html, Encode::FB_CROAK)
+    unless utf8::is_utf8($html);
+
+  return $html;
+}
+
+sub parse_synhi_param {
+  my ($self, $str) = @_;
+
+  my @opts = split /\s+/, $str;
+
+  confess 'no filetype provided for VimHTML region' unless @opts;
+  confess "illegal VimHTML region parameter: $str"
+    unless @opts == 1 and $opts[0] !~ /:/;
+
+  return { filetype => $opts[0] };
+}
+
+1;

--- a/t/vimhtml_utf8.t
+++ b/t/vimhtml_utf8.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+use v5.12.0;
+use strict;
+use warnings;
+use utf8;
+use charnames qw(:full);
+
+use Encode ();
+use Test::More;
+use Pod::Elemental::Transformer::VimHTML;
+
+my $open_q  = "\N{LEFT-POINTING DOUBLE ANGLE QUOTATION MARK}";
+my $close_q = "\N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK}";
+
+my $xform = Pod::Elemental::Transformer::VimHTML->new({
+  use_standard_wrapper => 0,
+});
+
+my $decoded_input = qq{debug "${open_q}\$firstLine${close_q} is proper markdown ho, ho, ho";\n};
+my $html = $xform->build_html($decoded_input, { filetype => 'perl' });
+
+like(
+  $html,
+  qr/\Q$open_q\E.*\Q$close_q\E/s,
+  'VimHTML preserves UTF-8 guillemets for decoded Perl text',
+);
+
+unlike(
+  $html,
+  qr/Â«|Â»/,
+  'VimHTML does not leave mojibake markers behind',
+);
+
+my $octet_input = Encode::encode('utf-8', $decoded_input, Encode::FB_CROAK);
+my $octet_html = $xform->build_html($octet_input, { filetype => 'perl' });
+
+like(
+  $octet_html,
+  qr/\Q$open_q\E.*\Q$close_q\E/s,
+  'VimHTML preserves guillemets for octet input',
+);
+
+done_testing;


### PR DESCRIPTION
This adds  to the existing forked  distribution used by Perl Advent.

Why:
- Perl Advent already carries this distribution as a git submodule fork
- PR perladvent/Perl-Advent#663 needs the UTF-8 mojibake fix for  highlighted blocks
- Keeping it here avoids introducing a separate top-level override mechanism in the parent repo

This is intended to be consumed by perladvent/Perl-Advent#663 via submodule update.